### PR TITLE
Export include directory to the cmake package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(mbh STATIC Utils.c IMRPhenomD.c IMRPhenomD_internals.c Response.c IM
 include_directories(SYSTEM ${GSL_INCLUDE_DIRS})
 target_link_libraries(mbh ${GSL_LIBRARIES} m)
 set_target_properties(mbh PROPERTIES PUBLIC_HEADER "mbh.h;IMRPhenomD.h;IMRPhenomD_internals.h;Declarations.h;Constants.h")
+target_include_directories(mbh PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include> )
 install(TARGETS mbh EXPORT MBHConfig LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include)
 export(TARGETS mbh NAMESPACE MBH:: FILE "MBHConfig.cmake")
 install(EXPORT MBHConfig DESTINATION lib/cmake/mbh NAMESPACE MBH::)


### PR DESCRIPTION
This change allows target_link_libraries in a consumer to find the include directory. There is a [PR in ldasoft](https://github.com/tlittenberg/ldasoft/pull/39) which depends on this code to work properly. If there are other consumers of MBH-globalfit this may break their build.

In the prior version, the .cmake file exported to the install directory did not contain any reference for where the include directory could be found. The ldasoft tree which consumes this as a library has some commented out lines to find the include directory, which appeard to be a workaround. With this change merged to global-fit the commented lines should no longer be necessary.

This is the relevant ldasoft PR: https://github.com/tlittenberg/ldasoft/pull/39